### PR TITLE
Pin Obsidian SDK to 1.8.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "builtin-modules": "3.3.0",
         "esbuild": "0.17.3",
         "eslint": "^8.57.0",
-        "obsidian": "latest",
+        "obsidian": "1.8.7",
         "tslib": "2.4.0",
         "typescript": "4.7.4"
       }
@@ -1688,16 +1688,6 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
     },
-    "node_modules/obsidian": {
-      "version": "0.12.17",
-      "resolved": "https://registry.npmjs.org/obsidian/-/obsidian-0.12.17.tgz",
-      "integrity": "sha512-YvCAlRym9D8zNPXt6Ez8QubSTVGoChx6lb58zqI13Dcrz3l1lgUO+pcOGDiD5Qa67nzDZLXo3aV2rqkCCpTvGQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/codemirror": "0.0.108",
-        "moment": "2.29.1"
-      }
-    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -3238,16 +3228,6 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
-    },
-    "obsidian": {
-      "version": "0.12.17",
-      "resolved": "https://registry.npmjs.org/obsidian/-/obsidian-0.12.17.tgz",
-      "integrity": "sha512-YvCAlRym9D8zNPXt6Ez8QubSTVGoChx6lb58zqI13Dcrz3l1lgUO+pcOGDiD5Qa67nzDZLXo3aV2rqkCCpTvGQ==",
-      "dev": true,
-      "requires": {
-        "@types/codemirror": "0.0.108",
-        "moment": "2.29.1"
-      }
     },
     "once": {
       "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "builtin-modules": "3.3.0",
     "esbuild": "0.17.3",
     "eslint": "^8.57.0",
-    "obsidian": "latest",
+    "obsidian": "1.8.7",
     "tslib": "2.4.0",
     "typescript": "4.7.4"
   }


### PR DESCRIPTION
## Summary
- pin the obsidian devDependency to the 1.8.7 SDK release in package.json and package-lock.json
- drop stale package-lock entries referencing the old obsidian 0.12.17 tarball so the lockfile no longer contradicts the pinned version

## Testing
- `npm install` *(fails: 403 Forbidden retrieving obsidian package from npm registry)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68d2942d6b2083339660f36e320f83b4