### PR TITLE
chore: override moment to 2.29.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "obsidian-collapse-all-plugin",
       "version": "2.1.0",
       "license": "MIT",
+      "overrides": {
+        "moment": "2.29.4"
+      },
       "devDependencies": {
         "@types/node": "^16.11.6",
         "@typescript-eslint/eslint-plugin": "^7.3.1",
@@ -1668,9 +1671,9 @@
       }
     },
     "node_modules/moment": {
-      "version": "2.29.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
-      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==",
+      "version": "2.29.4",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
+      "integrity": "sha512-C7+DSxGTFeoDyAJhDigw1VE3DybZ0SqnX+0Gooy2cuglRez2oJ6TP2PzefDs2fzGEylh4G6dkhOC5/hTyBCwRA==",
       "dev": true,
       "engines": {
         "node": "*"
@@ -3212,9 +3215,9 @@
       }
     },
     "moment": {
-      "version": "2.29.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
-      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==",
+      "version": "2.29.4",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
+      "integrity": "sha512-C7+DSxGTFeoDyAJhDigw1VE3DybZ0SqnX+0Gooy2cuglRez2oJ6TP2PzefDs2fzGEylh4G6dkhOC5/hTyBCwRA==",
       "dev": true
     },
     "ms": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,9 @@
     "url": "https://nathan-smith.org/"
   },
   "license": "MIT",
+  "overrides": {
+    "moment": "2.29.4"
+  },
   "devDependencies": {
     "@types/node": "^16.11.6",
     "@typescript-eslint/eslint-plugin": "^7.3.1",


### PR DESCRIPTION
## Summary
- add an overrides entry to force moment 2.29.4 when installing dependencies
- update the lockfile metadata so the resolved moment dependency reflects the override

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d2995f6ef483339c230f5fb9742395